### PR TITLE
feat: add support for bria manual payout queues

### DIFF
--- a/docs/resources/payout_queue.md
+++ b/docs/resources/payout_queue.md
@@ -34,7 +34,6 @@ description: |-
 Required:
 
 - `consolidate_deprecated_keychains` (Boolean)
-- `interval_secs` (Number)
 - `tx_priority` (String)
 
 Optional:
@@ -42,5 +41,7 @@ Optional:
 - `cpfp_payouts_after_blocks` (Number)
 - `cpfp_payouts_after_mins` (Number)
 - `force_min_change_sats` (Number)
+- `interval_secs` (Number)
+- `manual` (Boolean)
 
 

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -33,5 +33,6 @@ description: |-
 Optional:
 
 - `allowed_payout_addresses` (Set of String)
+- `max_payout_sats` (Number)
 
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -34,7 +34,7 @@ resource "bria_profile" "restricted" {
   name = "restricted-profile-${random_string.postfix.result}"
   spending_policy {
     allowed_payout_addresses = ["mgWUuj1J1N882jmqFxtDepEC73Rr22E9GU"]
-    max_payout_sats  = 1000000
+    max_payout_sats          = 1000000
   }
 }
 
@@ -118,5 +118,16 @@ resource "bria_payout_queue" "interval" {
     cpfp_payouts_after_blocks        = 2
     cpfp_payouts_after_mins          = 30
     force_min_change_sats            = 100000
+  }
+}
+
+resource "bria_payout_queue" "manual" {
+  name        = "manual-${random_string.postfix.result}"
+  description = "A manual trigger Bria payout queue"
+
+  config {
+    tx_priority                      = "NEXT_BLOCK"
+    consolidate_deprecated_keychains = false
+    manual                           = true
   }
 }


### PR DESCRIPTION
This pull request introduces support for manual triggering of Bria payout queues, alongside improvements to configuration handling and documentation. The most important changes are grouped below:

Manual payout queue support:

* Added a new `manual` boolean option to the payout queue configuration, allowing users to create queues that are triggered manually instead of on a time interval. This option is mutually exclusive with `interval_secs`. (`provider/payout_queue.go`, `example/main.tf`, `docs/resources/payout_queue.md`) [[1]](diffhunk://#diff-963dd933d7d9154ebb8dd76ff27d429a111a6f7b5842fd820529be54dfb7de3bR41-R51) [[2]](diffhunk://#diff-0cb0376130abd499bc48f48df046c1822b0b47211808250baca17b73c4327196R123-R133) [[3]](diffhunk://#diff-627532964ed7c45b88a421c67fd513e49999ad08622803a3cca323e13b0647cbL37-R45)
* Updated the payout queue resource logic to handle both manual and interval-based triggers, including changes to the schema, create/update/read operations, and documentation. (`provider/payout_queue.go`, `docs/resources/payout_queue.md`) [[1]](diffhunk://#diff-963dd933d7d9154ebb8dd76ff27d429a111a6f7b5842fd820529be54dfb7de3bR41-R51) [[2]](diffhunk://#diff-963dd933d7d9154ebb8dd76ff27d429a111a6f7b5842fd820529be54dfb7de3bL74-R84) [[3]](diffhunk://#diff-963dd933d7d9154ebb8dd76ff27d429a111a6f7b5842fd820529be54dfb7de3bL136-R127) [[4]](diffhunk://#diff-963dd933d7d9154ebb8dd76ff27d429a111a6f7b5842fd820529be54dfb7de3bR161-R189) [[5]](diffhunk://#diff-963dd933d7d9154ebb8dd76ff27d429a111a6f7b5842fd820529be54dfb7de3bL197-R210) [[6]](diffhunk://#diff-627532964ed7c45b88a421c67fd513e49999ad08622803a3cca323e13b0647cbL37-R45)

Configuration and documentation enhancements:

* Refactored payout queue config construction into a dedicated `buildPayoutQueueConfig` function to simplify creation and updating logic. (`provider/payout_queue.go`) [[1]](diffhunk://#diff-963dd933d7d9154ebb8dd76ff27d429a111a6f7b5842fd820529be54dfb7de3bL74-R84) [[2]](diffhunk://#diff-963dd933d7d9154ebb8dd76ff27d429a111a6f7b5842fd820529be54dfb7de3bR161-R189) [[3]](diffhunk://#diff-963dd933d7d9154ebb8dd76ff27d429a111a6f7b5842fd820529be54dfb7de3bL197-R210)
* Improved documentation for payout queue and profile resources, including new fields such as `manual` and `max_payout_sats`. (`docs/resources/payout_queue.md`, `docs/resources/profile.md`) [[1]](diffhunk://#diff-627532964ed7c45b88a421c67fd513e49999ad08622803a3cca323e13b0647cbL37-R45) [[2]](diffhunk://#diff-472482b8d6110eac73dba20493d71a86dc4e2f333b5f225a865e0408874e4cdbR36)